### PR TITLE
Added Scroll.wheelScrollSpeed variable

### DIFF
--- a/src/ru/stablex/ui/widgets/Scroll.hx
+++ b/src/ru/stablex/ui/widgets/Scroll.hx
@@ -41,6 +41,9 @@ class Scroll extends Widget{
     */
     public var box (_getBox,never) : Widget;
 
+    //determine how far mouse wheel deltas will scroll the content
+    public var wheelScrollSpeed : Float = 10;
+
     //scroll position along x axes
     public var scrollX (_getScrollX,_setScrollX) : Float;
     //scroll position along y axes
@@ -358,11 +361,11 @@ class Scroll extends Widget{
             )
         ){
             this.tweenStop();
-            this.scrollX += e.delta * 10;
+            this.scrollX += e.delta * wheelScrollSpeed;
         //scroll vertically
         }else if( this.vScroll ){
             this.tweenStop();
-            this.scrollY += e.delta * 10;
+            this.scrollY += e.delta * wheelScrollSpeed;
         }
     }//function _wheelScroll()
 


### PR DESCRIPTION
I added a wheelScrollSpeed variable with a default value of 10 to allow users to set how far the Scroll will move the content when a mouse wheel is used to interact with it.

It's a very small but useful fix. Is the name "wheelScrollSpeed" alright with you?
