### PR TITLE
Fix for issue #35 - builds for iOS fail, unable to find defaults.xml

### DIFF
--- a/src/ru/stablex/ui/UIBuilder.hx
+++ b/src/ru/stablex/ui/UIBuilder.hx
@@ -125,7 +125,7 @@ class UIBuilder {
 
         //If provided with file for defaults, generate closures for applying defaults to widgets
         if( defaultsXmlFile != null ){
-            var root : Xml = Xml.parse( File.getContent(defaultsXmlFile) ).firstElement();
+            var root : Xml = Xml.parse( File.getContent(Context.resolvePath(defaultsXmlFile)) ).firstElement();
             for(widget in root.elements()){
                 code += '\nif( !ru.stablex.ui.UIBuilder.defaults.exists("' + widget.nodeName + '") ) ru.stablex.ui.UIBuilder.defaults.set("' + widget.nodeName + #if haxe3 '", new Map());' #else '", new Hash());' #end;
                 for(node in widget.elements()){
@@ -665,7 +665,7 @@ class UIBuilder {
     macro static public function buildFn (xmlFile:String) : Expr{
         UIBuilder._checkInit();
 
-        var element = Xml.parse( File.getContent(xmlFile) ).firstElement();
+        var element = Xml.parse( File.getContent(Context.resolvePath(xmlFile)) ).firstElement();
         var cls : String = UIBuilder._imports.get(element.nodeName);
 
         #if display
@@ -724,7 +724,7 @@ class UIBuilder {
 
         UIBuilder._checkInit();
 
-        var element = Xml.parse( File.getContent(xmlFile) ).firstElement();
+        var element = Xml.parse( File.getContent(Context.resolvePath(xmlFile)) ).firstElement();
 
         var code   : String = '';
         var erSkin : EReg = ~/^([a-z0-9_]+):([a-z0-9_]+)$/i;


### PR DESCRIPTION
As noted in issue #35, adding a Context.resolvePath() around each xml file locates the file successfully, even in the iOS build case (where directories are somewhat different).
