### PR TITLE
Changed TabStack to dispatch CHANGE instead of REMOVED when switching tabs.

### DIFF
--- a/src/ru/stablex/ui/widgets/TabStack.hx
+++ b/src/ru/stablex/ui/widgets/TabStack.hx
@@ -141,7 +141,7 @@ class TabStack extends Box{
     */
     private function _onChange(e:MouseEvent) : Void {
         this.refresh();
-        this.dispatchEvent( new WidgetEvent(WidgetEvent.REMOVED) );
+        this.dispatchEvent( new WidgetEvent(WidgetEvent.CHANGE) );
     }//function _onChange()
 
 


### PR DESCRIPTION
TabStack is supposed to dispatch WidgetEvent.CHANGE(according to the documentation) when switching tabs.
