### PR TITLE
RealyUniqueName/StablexUI#163 Fixed ios macro skin path resolution.

### DIFF
--- a/src/ru/stablex/ui/UIBuilder.hx
+++ b/src/ru/stablex/ui/UIBuilder.hx
@@ -799,7 +799,7 @@ class UIBuilder {
 
         //load skins from xml files
         if( xmlFile != null ){
-            var element = Xml.parse( File.getContent(xmlFile) ).firstElement();
+            var element = Xml.parse( File.getContent(Context.resolvePath(xmlFile)) ).firstElement();
 
             var erSkin    : EReg = ~/^([a-z0-9_]+):([a-z0-9_]+)$/i;
             var local     : String = '';


### PR DESCRIPTION
`Context.resolvePath` fixes iOS path for macro as mentioned in openfl/openfl#57.
