### PR TITLE
Added: ability to specify transition easing (for ViewStacks etc)

### DIFF
--- a/src/ru/stablex/ui/transitions/Fade.hx
+++ b/src/ru/stablex/ui/transitions/Fade.hx
@@ -24,7 +24,7 @@ class Fade extends Transition{
             w.tweenStop("alpha", true, true);
             w.alpha = 1;
             w.top   = w.left = 0;
-            w.tween(this.duration, {alpha:0}).onComplete(this._hide, [toHide, cb]);
+            w.tween(this.duration, {alpha:0}, this.easing).onComplete(this._hide, [toHide, cb]);
             // Ensure callback is not called below
             cb = null;
         }
@@ -36,7 +36,7 @@ class Fade extends Transition{
             w.visible = true;
             w.alpha   = 0;
             w.top     = w.left = 0;
-            w.tween(this.duration, {alpha:1}).onComplete(this._hide, [toHide, cb]);
+            w.tween(this.duration, {alpha:1}, this.easing).onComplete(this._hide, [toHide, cb]);
         }else{
             if (toHide != null) {
               toHide.visible = false;

--- a/src/ru/stablex/ui/transitions/Scale.hx
+++ b/src/ru/stablex/ui/transitions/Scale.hx
@@ -100,7 +100,7 @@ class Scale extends Transition{
                 left   : w.left + w.width / 2,
                 scaleX : 0,
                 scaleY : 0
-            }).onComplete(this._hide, [vs, toHide, toShow, swap, {left : w.left, top : w.top, scaleX : w.scaleX, scaleY : w.scaleY}, cb]);
+            }, this.easing).onComplete(this._hide, [vs, toHide, toShow, swap, {left : w.left, top : w.top, scaleX : w.scaleX, scaleY : w.scaleY}, cb]);
         }else{
             if (toHide != null) {
               toHide.visible = false;
@@ -162,7 +162,7 @@ class Scale extends Transition{
                 left   : leftGoal,
                 scaleX : scaleXGoal,
                 scaleY : scaleYGoal
-            }).onComplete(this._hide, [vs, toHide, toShow, swap, null, cb]);
+            }, this.easing).onComplete(this._hide, [vs, toHide, toShow, swap, null, cb]);
         }else{
             if( cb != null ) cb();
         }

--- a/src/ru/stablex/ui/transitions/Slide.hx
+++ b/src/ru/stablex/ui/transitions/Slide.hx
@@ -83,7 +83,7 @@ class Slide extends Transition{
         if( Std.is(toHide, Widget) ){
             w = cast(toHide, Widget);
             w.tweenStop("right", true, true);
-            w.tween(this.duration, {right:vs.w}).onComplete(this._hide,[toHide,cb]);
+            w.tween(this.duration, {right:vs.w}, this.easing).onComplete(this._hide,[toHide,cb]);
             // Set cb to null, so that it is not called bellow
             cb = null;
         } else {
@@ -99,7 +99,7 @@ class Slide extends Transition{
             w.visible = true;
             var leftGoal = w.left;
             w.left    = vs.w;
-            w.tween(this.duration, {left:leftGoal}).onComplete(_callCallback, [cb]);
+            w.tween(this.duration, {left:leftGoal}, this.easing).onComplete(_callCallback, [cb]);
             // Set cb to null, so that it is not called bellow
             cb = null;
         }else{
@@ -122,7 +122,7 @@ class Slide extends Transition{
         if( Std.is(toHide, Widget) ){
             w = cast(toHide, Widget);
             w.tweenStop("left", true, true);
-            w.tween(this.duration, {left:vs.w}).onComplete(this._hide,[toHide,cb]);
+            w.tween(this.duration, {left:vs.w}, this.easing).onComplete(this._hide,[toHide,cb]);
             // Set cb to null, so that it is not called bellow
             cb = null;
         } else {
@@ -138,7 +138,7 @@ class Slide extends Transition{
             w.visible = true;
             var leftGoal = w.left;
             w.right    = vs.w;
-            w.tween(this.duration, {left:leftGoal}).onComplete(_callCallback, [cb]);
+            w.tween(this.duration, {left:leftGoal}, this.easing).onComplete(_callCallback, [cb]);
             // Set cb to null, so that it is not called bellow
             cb = null;
         }else{
@@ -161,7 +161,7 @@ class Slide extends Transition{
         if( Std.is(toHide, Widget) ){
             w = cast(toHide, Widget);
             w.tweenStop("bottom", true, true);
-            w.tween(this.duration, {bottom:vs.h}).onComplete(this._hide,[toHide,cb]);
+            w.tween(this.duration, {bottom:vs.h}, this.easing).onComplete(this._hide,[toHide,cb]);
             // Set cb to null, so that it is not called bellow
             cb = null;
         } else {
@@ -177,7 +177,7 @@ class Slide extends Transition{
             w.visible = true;
             var topGoal = w.top;
             w.top    = vs.h;
-            w.tween(this.duration, {top:topGoal}).onComplete(_callCallback, [cb]);
+            w.tween(this.duration, {top:topGoal}, this.easing).onComplete(_callCallback, [cb]);
             // Set cb to null, so that it is not called bellow
             cb = null;
         }else{
@@ -200,7 +200,7 @@ class Slide extends Transition{
         if( Std.is(toHide, Widget) ){
             w = cast(toHide, Widget);
             w.tweenStop("top", true, true);
-            w.tween(this.duration, {top:vs.h}).onComplete(this._hide,[toHide,cb]);
+            w.tween(this.duration, {top:vs.h}, this.easing).onComplete(this._hide,[toHide,cb]);
             // Set cb to null, so that it is not called bellow
             cb = null;
         } else {
@@ -216,7 +216,7 @@ class Slide extends Transition{
             w.visible = true;
             var topGoal = w.top;
             w.bottom    = vs.h;
-            w.tween(this.duration, {top:topGoal}).onComplete(_callCallback, [cb]);
+            w.tween(this.duration, {top:topGoal}, this.easing).onComplete(_callCallback, [cb]);
             // Set cb to null, so that it is not called bellow
             cb = null;
         }else{

--- a/src/ru/stablex/ui/transitions/Transition.hx
+++ b/src/ru/stablex/ui/transitions/Transition.hx
@@ -13,6 +13,8 @@ class Transition {
 
     //Duration of transition in seconds
     public var duration : Float = 1;
+    //Easing method to use
+    public var easing : String = 'Linear.easeNone';
 
 
     /**


### PR DESCRIPTION
**Linear.easeNone** looked a bit harsh for ViewStack transitions, especially for mobile apps. You can now specify.

Nice and smooth (higher stage.frameRate recommended):

```
<ViewStack
    trans:Slide-direction="'left'"
    trans:Slide-duration="0.4"
    trans:Slide-easing="'Expo.easeOut'"
>
```
