### PR TITLE
Fixed: defaults did not work for runtime xml

### DIFF
--- a/src/ru/stablex/ui/RTXml.hx
+++ b/src/ru/stablex/ui/RTXml.hx
@@ -133,7 +133,8 @@ class RTXml {
         //attributes
         for(attr in node.attributes()){
             if(attr == "defaults"){
-                cache.defaults = node.get(attr);
+                var expression = RTXml.parser.parseString( Attribute.fillShortcuts( node.get(attr) ) );
+                cache.defaults = interp.execute(expression);
             }else{
                 cache.data.push( new Attribute(attr, node.get(attr)) );
             }


### PR DESCRIPTION
RTXml read the defaults attribute wrong (as a direct value rather than as a haxe string expression)
