### PR TITLE
Img skins can now scale using aspect ratio (centered) and crop to fill space

### DIFF
--- a/src/ru/stablex/ui/skins/Img.hx
+++ b/src/ru/stablex/ui/skins/Img.hx
@@ -26,6 +26,8 @@ class Img extends Skin{
     public var scaleImg = false;
     // If set to true and scaleImg is set to true, will maintain the aspect ratio of the image whilst scaling
     public var keepAspect : Bool = false;
+    // If set to true as well as scaleImg and keepAspect the image will be cropped such that it fills the entire widget space
+    public var crop : Bool = false;
 
 
     /**
@@ -53,7 +55,7 @@ class Img extends Skin{
             var scaleX = w.w/bmp.width;
             var scaleY = w.h/bmp.height;
             if(keepAspect){
-                var scale = Math.min(scaleX, scaleY);
+                var scale = crop?Math.max(scaleX, scaleY):Math.min(scaleX, scaleY);
                 matrix.scale(scale, scale);
                 matrix.translate((w.w-bmp.width*scale)*0.5, (w.h-bmp.height*scale)*0.5);
             }else{


### PR DESCRIPTION
Center background image skin within widget, centered, whilst maintaining aspect ratio:

```
<Widget
    width="200"
    height="200"
    skin:Img-src="'image.png'"
    skin:Img-scaleImg="true"
    skin:Img-keepAspect="true"
>
```

Fill entire widget with proportionally correct image. Crop off edges to fill space. Good for scaling background images:

```
<Widget
    widthPt="100"
    heightPt="100"
    skin:Img-src="'background.png'"
    skin:Img-scaleImg="true"
    skin:Img-keepAspect="true"
    skin:Img-crop="true"
>
```
