### PR TITLE
bug fixes for using Scale transition on flash target.

### DIFF
--- a/src/ru/stablex/ui/transitions/Scale.hx
+++ b/src/ru/stablex/ui/transitions/Scale.hx
@@ -93,7 +93,7 @@ class Scale extends Transition{
             w.tweenStop(["scaleX", "scaleY", "left", "top"], true, true);
 
             //swap objects if needed
-            if( vs.getChildIndex(toHide) < vs.getChildIndex(toShow) ){
+            if( toHide != null && toShow != null && vs.getChildIndex(toHide) < vs.getChildIndex(toShow) ){
                 swap = true;
                 vs.swapChildren(toHide, toShow);
             }
@@ -150,7 +150,7 @@ class Scale extends Transition{
             w.tweenStop(["scaleX", "scaleY", "left", "top"], true, true);
 
             //swap objects if needed
-            if( vs.getChildIndex(toHide) > vs.getChildIndex(toShow) ){
+            if( toHide != null && toShow != null && vs.getChildIndex(toHide) > vs.getChildIndex(toShow) ){
                 swap = true;
                 vs.swapChildren(toHide, toShow);
             }


### PR DESCRIPTION
On flash target getChildIndex may not be called with "null" as parameter.
