### PR TITLE
ignore 'xmlns' and 'xsi' attributes when parsing StablexUI XML tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ samples/tests/*
 docGen/doc/*
 *.zip
 build.hxml
+.idea/*

--- a/src/ru/stablex/ui/UIBuilder.hx
+++ b/src/ru/stablex/ui/UIBuilder.hx
@@ -449,6 +449,12 @@ class UIBuilder {
         while( attributes.hasNext() ){
             attr = attributes.next();
 
+            //filtering out XML namespace attributes ('xmlns' or 'xmlns:')
+            if (attr == 'xmlns' || attr.indexOf('xmlns:') == 0) continue;
+
+            //filtering out XSI schema attributes ('xsi' or 'xsi:')
+            if (attr == 'xsi' || attr.indexOf('xsi:') == 0) continue;
+
             //if this attribute defines class casting, leave it for the end
             if( attr.indexOf(':') != -1 ){
                 post.push(attr);


### PR DESCRIPTION
makes StablexUI parser ignore 'xmlns' (XML namespace) and 'xsi' (XML schema instance) attributes in StablexUI XML tags ... 
(needed to provide a smooth Code completion experience, 
...as discussed in our Slack Chat talk from Feb 10th, 2015)