### PR TITLE
When migrate a flash project to openfl + stablexui, I need declare many ...

### DIFF
--- a/src/ru/stablex/ui/ClassBuilder.hx
+++ b/src/ru/stablex/ui/ClassBuilder.hx
@@ -275,7 +275,7 @@ class ClassBuilder {
         }
 
         //call .onInitialize method to notify widget that it is initialized
-        code += '\n'+ widget + '._onInitialize();';
+        code += UIBuilder.callIfWidget(widget, '_onInitialize()');
 
         //if we have nested widgets, generate code for them
         for(node in element.elements()){
@@ -294,7 +294,7 @@ class ClassBuilder {
         }
 
         //call .onCreate method to notify widget that it is created
-        code += '\n'+ widget + '._onCreate();';
+        code += UIBuilder.callIfWidget(widget, '_onCreate()');
 
         //add to parent's display list
         code += '\n'+ parent + '.addChild('+ widget + ');';


### PR DESCRIPTION
...exist classes (that `extends Sprite` - and have a no-arg constructor - but NOT `extends Widget`) in xml ui.

ex, I have class `MyView extends Sprite` and want to declare an ui as:
```xml
<Widget> <MyView someProp="someValue" /> </Widget>
```
This commit cleanup some code & add that ability to stablexui