### PR TITLE
Haxe4

### DIFF
--- a/samples/demo/ui/tabs.xml
+++ b/samples/demo/ui/tabs.xml
@@ -18,7 +18,7 @@
                         for(i in 0...ts.numChildren){
                             tab = ( Std.is(ts.getChildAt(i), $TabPage) ? cast(ts.getChildAt(i), $TabPage) : null);
                             if( tab != null ){
-                                tab.title.states.down.skinName = 'tabBottomActive';
+                                tab.title.states.resolve('down').skinName = 'tabBottomActive';
                                 tab.title.skinPressedName = 'tabBottomPressed';
                                 tab.title.updateState();
                             }
@@ -37,7 +37,7 @@
                         for(i in 0...ts.numChildren){
                             tab = ( Std.is(ts.getChildAt(i), $TabPage) ? cast(ts.getChildAt(i), $TabPage) : null);
                             if( tab != null ){
-                                tab.title.states.down.skinName = 'tabActive';
+                                tab.title.states.resolve('down').skinName = 'tabActive';
                                 tab.title.skinPressedName = 'tabPressed';
                                 tab.title.updateState();
                             }

--- a/src/ru/stablex/DynamicList.hx
+++ b/src/ru/stablex/DynamicList.hx
@@ -7,7 +7,7 @@ package ru.stablex;
 * New object is created every time you request an undefined property.
 * So dynamicListInstance.someProperty never returns null
 */
-class DynamicList<T> implements Dynamic<T>{
+class DynamicList<T> #if !haxe4 implements Dynamic<T> #end{
     //class for objects in this list
     private var _cls : Class<T>;
     #if haxe3

--- a/src/ru/stablex/ui/Dnd.hx
+++ b/src/ru/stablex/ui/Dnd.hx
@@ -1,5 +1,6 @@
 package ru.stablex.ui;
 
+import flash.events.IEventDispatcher;
 import flash.display.DisplayObjectContainer;
 import flash.events.MouseEvent;
 import flash.geom.Point;
@@ -91,7 +92,7 @@ class Dnd {
             var receive = Dnd.current.cloneWithType(DndEvent.RECEIVE);
 
             Dnd.current.obj.dispatchEvent( drop );
-            e.target.dispatchEvent( receive );
+            cast (e.target, IEventDispatcher).dispatchEvent( receive );
         }
     }//function _onDrop()
 

--- a/src/ru/stablex/ui/Theme.hx
+++ b/src/ru/stablex/ui/Theme.hx
@@ -337,10 +337,14 @@ class Theme {
                         if( !field.isPublic ) continue;
 
                         var type = TypeTools.toString(field.type);
+                        var tprim = type;
                         type = type.substring(type.indexOf(':') + 1, type.length).trim();
+                        type = StringTools.replace(type, ")", "");
 
                         if( type == 'ru.stablex.ui.widgets.Widget -> Void' ){
                             defaults.push(field.name);
+                        } else {
+                            throw '${cls}.${field.name}() should be Widget -> Void'  +  " \n but it is " + tprim;
                         }
                     }
                 case _: throw cls + ' must be a class without type parameters';

--- a/src/ru/stablex/ui/UIBuilder.hx
+++ b/src/ru/stablex/ui/UIBuilder.hx
@@ -786,12 +786,13 @@ class UIBuilder {
     *
     * @throw <type>String</type> if this shortcut is already used
     */
-    macro static public function regEvent (shortcut:String, eventType:String, eventClass:String = 'flash.events.Event') : Expr{
+#if macro
+    static public function regEvent (shortcut:String, eventType:String, eventClass:String = 'flash.events.Event') : Expr{
         if( UIBuilder._events.exists(shortcut) ) Err.trigger('Event is already registered: ' + shortcut);
         UIBuilder._events.set(shortcut, [eventType, eventClass]);
         return Context.parse('true', Context.currentPos());
     }//function register()
-
+#end
 
     /**
     * Register class to use it in xml code.

--- a/src/ru/stablex/ui/layouts/Column.hx
+++ b/src/ru/stablex/ui/layouts/Column.hx
@@ -13,7 +13,7 @@ import ru.stablex.ui.widgets.Box; // To accrss static method _objWidth
 */
 class Column extends Layout{
     //Setter for padding left, right, top, bottom.
-    public var padding (never,set_padding) : Float;
+    public var padding (never,set) : Float;
     //padding left
     public var paddingLeft   : Float = 0;
     //padding right
@@ -25,7 +25,7 @@ class Column extends Layout{
     //Distance between children
     public var cellPadding : Float = 0;
     //Set children widget size according to column size
-    public var fit(null, set_fit) : Bool;
+    public var fit(null, set) : Bool;
     public var fitWidth : Bool = true;
     public var fitHeight : Bool = true;
     // Vertical alignment (middle,bottom,top)

--- a/src/ru/stablex/ui/layouts/Row.hx
+++ b/src/ru/stablex/ui/layouts/Row.hx
@@ -13,7 +13,7 @@ import ru.stablex.ui.widgets.Box; // To acces static method _objHeight
 */
 class Row extends Layout{
     //Setter for padding left, right, top, bottom.
-    public var padding (never,set_padding) : Float;
+    public var padding (never,set) : Float;
     //padding left
     public var paddingLeft   : Float = 0;
     //padding right
@@ -25,7 +25,7 @@ class Row extends Layout{
     //Distance between children
     public var cellPadding : Float = 0;
     //Set children widget size according to row size
-    public var fit(null, set_fit) : Bool;
+    public var fit(null, set) : Bool;
     public var fitWidth : Bool = true;
     public var fitHeight : Bool = true;
     // Horizontal alignment (center,left,right)

--- a/src/ru/stablex/ui/misc/BtnState.hx
+++ b/src/ru/stablex/ui/misc/BtnState.hx
@@ -12,10 +12,10 @@ class BtnState {
     //button label for this state
     public var text : String;
     //icon for this state
-    public var ico (get_ico,set_ico): Bmp;
+    public var ico (get,set): Bmp;
     public var _ico : Bmp;
     //skin name for this state (skin must be registered with <type>UIBuilder</type>.regSkins() )
-    public var skinName (default,set_skinName) : String;
+    public var skinName (default,set) : String;
     //skin for this state
     public var skin : Skin;
 

--- a/src/ru/stablex/ui/skins/Aswing.hx
+++ b/src/ru/stablex/ui/skins/Aswing.hx
@@ -34,7 +34,7 @@ class Aswing extends Skin {
     //padding for left border
     public var paddingLeft : Float = 0;
     //set equal padding for all borders
-    public var padding(never,set_padding) : Float;
+    public var padding(never,set) : Float;
     //gradient type (linear or radial)
     public var type : String = 'linear';
 

--- a/src/ru/stablex/ui/skins/Img.hx
+++ b/src/ru/stablex/ui/skins/Img.hx
@@ -12,14 +12,14 @@ import flash.display.BitmapData;
 */
 class Img extends Skin{
     //Asset ID or path to bitmap
-    public var src (get_src,set_src): String;
+    public var src (get,set): String;
     public var _src : String = null;
     /**
     * Use this property instead of `.src`, if you need to directly assign BitmapData instance.
     * `.bitmapData` will be set to null automatically, if you set `.src`.
     * `.src` will be set to null automatically, if you set `.bitmapData`
     */
-    public var bitmapData (get_bitmapData,set_bitmapData) : BitmapData;
+    public var bitmapData (get,set) : BitmapData;
     private var _bitmapData : BitmapData = null;
     //Smooth bitmap?
     public var smooth : Bool = true;

--- a/src/ru/stablex/ui/skins/Rect.hx
+++ b/src/ru/stablex/ui/skins/Rect.hx
@@ -28,7 +28,7 @@ class Rect extends Skin{
     //padding for left border
     public var paddingLeft : Float = 0;
     //set equal padding for all borders
-    public var padding(never,set_padding) : Float;
+    public var padding(never,set) : Float;
 
 
     /**

--- a/src/ru/stablex/ui/skins/Slice3.hx
+++ b/src/ru/stablex/ui/skins/Slice3.hx
@@ -15,14 +15,14 @@ import ru.stablex.ui.widgets.Widget;
 */
 class Slice3 extends Skin {
     //Asset ID or path to bitmap
-    public var src (get_src,set_src): String;
+    public var src (get,set): String;
     public var _src : String = null;
     /**
     * Use this property instead of `.src`, if you need to directly assign BitmapData instance.
     * `.bitmapData` will be set to null automatically, if you set `.src`.
     * `.src` will be set to null automatically, if you set `.bitmapData`
     */
-    public var bitmapData (get_bitmapData,set_bitmapData) : BitmapData;
+    public var bitmapData (get,set) : BitmapData;
     private var _bitmapData : BitmapData = null;
     //should we use smoothing?
     public var smooth : Bool = true;
@@ -38,7 +38,7 @@ class Slice3 extends Skin {
     //padding for left border
     public var paddingLeft : Float = 0;
     //set equal padding for all borders
-    public var padding(never,set_padding) : Float;
+    public var padding(never,set) : Float;
 
     /**
     * Setter for padding

--- a/src/ru/stablex/ui/skins/Tile.hx
+++ b/src/ru/stablex/ui/skins/Tile.hx
@@ -15,14 +15,14 @@ import ru.stablex.ui.widgets.Widget;
 */
 class Tile extends Rect{
     //Asset ID or path to bitmap
-    public var src (get_src,set_src): String;
+    public var src (get,set): String;
     public var _src : String = null;
     /**
     * Use this property instead of `.src`, if you need to directly assign BitmapData instance.
     * `.bitmapData` will be set to null automatically, if you set `.src`.
     * `.src` will be set to null automatically, if you set `.bitmapData`
     */
-    public var bitmapData (get_bitmapData,set_bitmapData) : BitmapData;
+    public var bitmapData (get,set) : BitmapData;
     private var _bitmapData : BitmapData = null;
     //should we use smoothing?
     public var smooth : Bool = false;

--- a/src/ru/stablex/ui/themes/android4/defaults/Checkbox.hx
+++ b/src/ru/stablex/ui/themes/android4/defaults/Checkbox.hx
@@ -22,8 +22,8 @@ class Checkbox {
         check.format.color = 0xFFFFFF;
         check.label.embedFonts = true;
 
-        check.states.up.ico.bitmapData   = Main.getBitmapData('img/checkbox.png');
-        check.states.down.ico.bitmapData = Main.getBitmapData('img/checkboxChecked.png');
+        check.states.resolve("up").ico.bitmapData   = Main.getBitmapData('img/checkbox.png');
+        check.states.resolve("down").ico.bitmapData = Main.getBitmapData('img/checkboxChecked.png');
     }//function Default()
 
 }//class Checkbox

--- a/src/ru/stablex/ui/themes/android4/defaults/Radio.hx
+++ b/src/ru/stablex/ui/themes/android4/defaults/Radio.hx
@@ -22,8 +22,8 @@ class Radio {
         check.format.color = 0xFFFFFF;
         check.label.embedFonts = true;
 
-        check.states.up.ico.bitmapData   = Main.getBitmapData('img/radio.png');
-        check.states.down.ico.bitmapData = Main.getBitmapData('img/radioChecked.png');
+        check.states.resolve("up").ico.bitmapData   = Main.getBitmapData('img/radio.png');
+        check.states.resolve("down").ico.bitmapData = Main.getBitmapData('img/radioChecked.png');
     }//function Default()
 
 }//class Radio

--- a/src/ru/stablex/ui/themes/android4/defaults/TabPage.hx
+++ b/src/ru/stablex/ui/themes/android4/defaults/TabPage.hx
@@ -19,10 +19,10 @@ class TabPage {
         var tab = cast(w, WTabPage);
         tab.title.w = 120;
         tab.title.h = 48;
-        tab.title.states.up.ico        = null;
-        tab.title.states.down.ico      = null;
-        tab.title.states.up.skinName   = 'tab';
-        tab.title.states.down.skinName = 'tabActive';
+        tab.title.states.resolve("up").ico        = null;
+        tab.title.states.resolve("down").ico      = null;
+        tab.title.states.resolve("up").skinName   = 'tab';
+        tab.title.states.resolve("down").skinName = 'tabActive';
         tab.title.skinPressedName      = 'tabPressed';
     }//function Default()
 

--- a/src/ru/stablex/ui/themes/android4/defaults/Toggle.hx
+++ b/src/ru/stablex/ui/themes/android4/defaults/Toggle.hx
@@ -22,8 +22,8 @@ class Toggle {
         //the same as StateButton
         StateButton.Default(btn);
 
-        btn.states.up.skinName   = 'button';
-        btn.states.down.skinName = 'buttonPressed';
+        btn.states.resolve("up").skinName   = 'button';
+        btn.states.resolve("down").skinName = 'buttonPressed';
     }//function Default()
 
 }//class Toggle

--- a/src/ru/stablex/ui/widgets/Bmp.hx
+++ b/src/ru/stablex/ui/widgets/Bmp.hx
@@ -13,7 +13,7 @@ import ru.stablex.Err;
 
 class Bmp extends Widget{
     //Asset ID or path to bitmap
-    public var src (get_src,set_src): String;
+    public var src (get,set): String;
     @:noCompletion public var _src : String = null;
     //Should we use smoothing?
     public var smooth : Bool = true;
@@ -22,7 +22,7 @@ class Bmp extends Widget{
     /** keep aspect ratio if `.stretch` is set to true? */
     public var keepAspect : Bool = false;
     //set size depending on bitmap size
-    public var autoSize (never,set_autoSize) : Bool;
+    public var autoSize (never,set) : Bool;
     //set width depending on bitmap width
     public var autoWidth : Bool = true;
     //set height depending on bitmap height
@@ -32,7 +32,7 @@ class Bmp extends Widget{
     * `.bitmapData` will be set to null automatically, if you set `.src`.
     * `.src` will be set to null automatically, if you set `.bitmapData`
     */
-    public var bitmapData (get_bitmapData,set_bitmapData) : BitmapData;
+    public var bitmapData (get,set) : BitmapData;
     @:noCompletion private var _bitmapData : BitmapData = null;
     /**
     * If you want to draw just a portion of the bitmap. Specify top/left corner of
@@ -41,9 +41,9 @@ class Bmp extends Widget{
     * width and height will be taken from `.xOffset` and `.yOffset` to bitmap right border
     * and bottom border respectively
     */
-    public var xOffset (default, set_xOffset) : Int = 0;
+    public var xOffset (default, set) : Int = 0;
     // y offset for drawing a portion of the bitmap
-    public var yOffset (default, set_yOffset) : Int = 0;
+    public var yOffset (default, set) : Int = 0;
     /**
     * When `.xOffset` or `.yOffset` is set, this property is changed to true.
     * To draw full image on next refresh set this property to false again.

--- a/src/ru/stablex/ui/widgets/Box.hx
+++ b/src/ru/stablex/ui/widgets/Box.hx
@@ -15,7 +15,7 @@ class Box extends Widget{
     //Should we arrange children vertically (true) or horizontally (false). True by default.
     public var vertical : Bool = true;
     //Setter for padding left, right, top, bottom.
-    public var padding (never,set_padding) : Float;
+    public var padding (never,set) : Float;
     //padding left
     public var paddingLeft   : Float = 0;
     //padding right
@@ -33,7 +33,7 @@ class Box extends Widget{
     */
     public var align : String = 'center,middle';
     //set size depending on content size
-    public var autoSize (never,set_autoSize) : Bool;
+    public var autoSize (never,set) : Bool;
     //set width depending on content width
     public var autoWidth                     : Bool = true;
     //set height depending on content height

--- a/src/ru/stablex/ui/widgets/Button.hx
+++ b/src/ru/stablex/ui/widgets/Button.hx
@@ -17,7 +17,7 @@ class Button extends Text{
     //Wether mouse pointer is currently over this button
     public var hovered (default,null) : Bool = false;
     //whether button is currently disabled
-    public var disabled (default,set_disabled) : Bool = false;
+    public var disabled (default,set) : Bool = false;
     //this.format.color value wiil be set when this.disabled set to true
     public var disabledFormatColor : UInt = 0x000000;
     /** this.mouseChildren value before this.disabled was set to true */
@@ -25,32 +25,32 @@ class Button extends Text{
     //this.fromat.color value before this.disabled was set tot true
     private var _formatColorBeforeDisabled : UInt;
     //default icon for button
-    public var ico (get_ico,set_ico): Bmp;
+    public var ico (get,set): Bmp;
     private var _ico : Bmp;
     //icon for hovered state
-    public var icoHovered (get_icoHovered,set_icoHovered) : Bmp;
+    public var icoHovered (get,set) : Bmp;
     private var _icoHovered : Bmp;
     //icon for pressed state
-    public var icoPressed (get_icoPressed,set_icoPressed) : Bmp;
+    public var icoPressed (get,set) : Bmp;
     private var _icoPressed : Bmp;
     //icon for disabled state
-    public var icoDisabled (get_icoDisabled,set_icoDisabled) : Bmp;
+    public var icoDisabled (get,set) : Bmp;
     private var _icoDisabled : Bmp;
     /**
     * Whether icon should appear before text (on left or on top of text), set to false to move icon to the right (or below) text
     * If you want icon to appear on top of label (or below) you also need to set button.vertical = true.
     */
-    public var icoBeforeLabel (default,set_icoBeforeLabel) : Bool = true;
+    public var icoBeforeLabel (default,set) : Bool = true;
     //skin name for hovered state (skin must be registered with <type>UIBuilder</type>.regSkins() )
-    public var skinHoveredName (default,set_skinHoveredName) : String;
+    public var skinHoveredName (default,set) : String;
     //skin for hovered state
     public var skinHovered : Skin;
     //skin name for pressed state (skin must be registered with <type>UIBuilder</type>.regSkins() )
-    public var skinPressedName (default,set_skinPressedName) : String;
+    public var skinPressedName (default,set) : String;
     //skin for pressed state
     public var skinPressed : Skin;
     //skin name for disabled state (skin must be registered with <type>UIBuilder</type>.regSkins() )
-    public var skinDisabledName (default,set_skinDisabledName) : String;
+    public var skinDisabledName (default,set) : String;
     //skin for disabled state
     public var skinDisabled : Skin;
     //stick ico and text to opposite borders

--- a/src/ru/stablex/ui/widgets/Clock.hx
+++ b/src/ru/stablex/ui/widgets/Clock.hx
@@ -15,7 +15,7 @@ class Clock extends Text{
     //Count seconds forward or backward (to zero)
     public var forward : Bool = true;
     //current amount of seconds
-    public var value (default,set_value) : Int = 0;
+    public var value (default,set) : Int = 0;
     //use leading zero for numbers less than 10
     public var leadingZero : Bool = true;
     //timer object
@@ -25,7 +25,7 @@ class Clock extends Text{
     * %h, %m, %s - hours, minutes, seconds respectively, without leading zeroes
     * %H, %M, %S - with leading zeroes
     */
-    public var timeFormat (default,set_timeFormat) : String = "%H:%M:%S";
+    public var timeFormat (default,set) : String = "%H:%M:%S";
     private var _hrsIdx : Int = 0;
     private var _minIdx : Int = 3;
     private var _secIdx : Int = 6;

--- a/src/ru/stablex/ui/widgets/Options.hx
+++ b/src/ru/stablex/ui/widgets/Options.hx
@@ -24,13 +24,13 @@ class Options extends Button{
     * First element in these pairs must be of <type>String</type> type.
     * First option is selected by default
     */
-    public var options (default,set_options) : Array<Array<Dynamic>>;
+    public var options (default,set) : Array<Array<Dynamic>>;
     //List wich appears when control is clicked
     public var list : Floating;
     //box is a child for `.list` and contains buttons for each option
     public var box : Box;
     //Currently selected value. If you try to set value wich is not in the `.options`, than `.value` won't be changed
-    public var value (get_value,set_value) : Dynamic;
+    public var value (get,set) : Dynamic;
     //defaults for options in list (each option is a <type>Toggle</type> widget)
     public var optionDefaults : String = 'Default';
     //If this is true. List position will be overriden to make list appear under this control
@@ -41,7 +41,7 @@ class Options extends Button{
     //if `true` then next assignment to `options` or `value` will not trigger `WidgetEvent.CHANGE`
     private var _skipNextChangeEvent : Bool = false;
     //currently selected option index in `.options`
-    private var _selectedIdx (default,set__selectedIdx) : Int = 0;
+    private var _selectedIdx (default,set) : Int = 0;
 
     //transition for changing children
     public var trans : Transition = null;

--- a/src/ru/stablex/ui/widgets/Progress.hx
+++ b/src/ru/stablex/ui/widgets/Progress.hx
@@ -15,9 +15,9 @@ import ru.stablex.ui.events.WidgetEvent;
 */
 class Progress extends Widget{
     //Maximum value.
-    public var max (default,set_max) : Float = 100;
+    public var max (default,set) : Float = 100;
     //current value
-    public var value (get_value,set_value) : Float;
+    public var value (get,set) : Float;
     private var _value : Float = 0;
     //bar
     public var bar : Widget;
@@ -26,7 +26,7 @@ class Progress extends Widget{
     /** distance from right border of background to right border of bar */
     public var paddingRight : Float = 0;
     //Whether user can click/tap/slide progress bar to change value
-    public var interactive (default,set_interactive) : Bool = false;
+    public var interactive (default,set) : Bool = false;
     //Visualize progress bar changes smoothly
     public var smoothChange : Bool = false;
     /**

--- a/src/ru/stablex/ui/widgets/Radio.hx
+++ b/src/ru/stablex/ui/widgets/Radio.hx
@@ -20,7 +20,7 @@ class Radio extends Checkbox{
 
 
     //group name for this control
-    public var group (default,set_group) : String;
+    public var group (default,set) : String;
 
 
     /**

--- a/src/ru/stablex/ui/widgets/Scroll.hx
+++ b/src/ru/stablex/ui/widgets/Scroll.hx
@@ -46,19 +46,19 @@ class Scroll extends Widget{
     * Container for content. Content is scrolled by moving this container.
     * This is always the first child of Scroll widget
     */
-    public var box (get_box,never) : Widget;
+    public var box (get,never) : Widget;
 
     //determine how far mouse wheel deltas will scroll the content
     public var wheelScrollSpeed : Float = 10;
 
     //scroll position along x axes
-    public var scrollX (get_scrollX,set_scrollX) : Float;
+    public var scrollX (get,set) : Float;
     //scroll position along y axes
-    public var scrollY (get_scrollY,set_scrollY) : Float;
+    public var scrollY (get,set) : Float;
     //vertical scroll bar
-    public var vBar (default,set_vBar) : Slider;
+    public var vBar (default,set) : Slider;
     //horizontal scroll bar
-    public var hBar (default,set_hBar) : Slider;
+    public var hBar (default,set) : Slider;
     /**
     * For neko and html5 targets onMouseDown dispatched several times (depends on display list depth)
     * We want to process it only once

--- a/src/ru/stablex/ui/widgets/Slider.hx
+++ b/src/ru/stablex/ui/widgets/Slider.hx
@@ -17,10 +17,10 @@ class Slider extends Widget{
     //Maximum value
     public var max : Float = 100;
     //Current value
-    public var value (get_value,set_value) : Float;
+    public var value (get,set) : Float;
     private var _value : Float = 0;
     //Step change in the value
-	public var step (get_step,set_step) : Float;
+	public var step (get,set) : Float;
 	private var _step : Float = 0;
     //Slider element
     public var slider : Widget;

--- a/src/ru/stablex/ui/widgets/StateButton.hx
+++ b/src/ru/stablex/ui/widgets/StateButton.hx
@@ -17,15 +17,15 @@ import ru.stablex.ui.skins.Skin;
 class StateButton extends Button{
 
     //change states on click
-    public var cycleStates(default,set_cycleStates) : Bool;
+    public var cycleStates(default,set) : Bool;
     //object to define button states
     public var states : DynamicList<BtnState>;
     //defines states order. Only states defined in this array will apear on button clicking
     public var order : Array<String>;
     //current state
-    public var state(get_state,set_state) : String;
+    public var state(get,set) : String;
     //current state index in this.order array
-    private var _currentIdx (default,set__currentIdx) : Int = 0;
+    private var _currentIdx (default,set) : Int = 0;
 
 
     /**

--- a/src/ru/stablex/ui/widgets/Switch.hx
+++ b/src/ru/stablex/ui/widgets/Switch.hx
@@ -20,7 +20,7 @@ class Switch extends Widget{
     //Slider element
     public var slider : Widget;
     //Indicates switch state. `true` for `on`-state, `false` for `off`-state. `true` by default
-    public var selected (get_selected,set_selected) : Bool;
+    public var selected (get,set) : Bool;
     private var _selected : Bool = true;
     //if user is pushing `.slider`
     private var _sliding : Bool = false;

--- a/src/ru/stablex/ui/widgets/Text.hx
+++ b/src/ru/stablex/ui/widgets/Text.hx
@@ -19,12 +19,12 @@ class Text extends Box{
     //Text format wich will be aplied to label on refresh
     public var format : TextFormat;
     //Text format for higlight mode
-    public var highlightFormat (get_highlightFormat,set_highlightFormat) : TextFormat;
+    public var highlightFormat (get,set) : TextFormat;
     private var _hightlightFormat : TextFormat;
     //indicates highlighting state
     public var highlighted (default,null) : Bool = false;
     //Getter-setter for text.
-    public var text (get_text,set_text) : String;
+    public var text (get,set) : String;
 
 
     /**

--- a/src/ru/stablex/ui/widgets/Tip.hx
+++ b/src/ru/stablex/ui/widgets/Tip.hx
@@ -18,7 +18,7 @@ class Tip extends Floating{
     //tooltip content
     public var label : Text;
     //Setter and getter for `.label.text`
-    public var text(get_text,set_text) : String;
+    public var text(get,set) : String;
 
 
     /**

--- a/src/ru/stablex/ui/widgets/Toggle.hx
+++ b/src/ru/stablex/ui/widgets/Toggle.hx
@@ -11,7 +11,7 @@ class Toggle extends StateButton{
     //should we `.highlight()` the text when button is toggled?
     public var highlightOnSelect : Bool = false;
     //whether button is in down/selected state
-    public var selected (get_selected,set_selected) : Bool;
+    public var selected (get,set) : Bool;
 
 
     /**

--- a/src/ru/stablex/ui/widgets/ViewStack.hx
+++ b/src/ru/stablex/ui/widgets/ViewStack.hx
@@ -17,9 +17,9 @@ class ViewStack extends Widget{
     private var _history : Array<Int>;
 
     //getter for .name of currently visible child
-    public var current (get_current,never)       : String;
+    public var current (get,never)       : String;
     //child index of currently visible child
-    public var currentIdx (get_currentIdx,never) : Int;
+    public var currentIdx (get,never) : Int;
     // wrap the stack list or not (for `.next()` calls)
     public var wrap : Bool = false;
     //transition for changing children

--- a/src/ru/stablex/ui/widgets/Widget.hx
+++ b/src/ru/stablex/ui/widgets/Widget.hx
@@ -42,11 +42,11 @@ class Widget extends TweenSprite{
     public var destroyed : Bool = false;
 
     //Widget width in pixels
-    public var w (get_w,set_w)   : Float;
+    public var w (get,set)   : Float;
     //Width of content area
-    public var contentWidth (get_contentWidth, null) : Float;
+    public var contentWidth (get, null) : Float;
     //Widget width in % of parent's width
-    public var widthPt (get_widthPt,set_widthPt) : Float;
+    public var widthPt (get,set) : Float;
     @:noCompletion private var _width                   : Float = 0;
     @:noCompletion private var _widthPercent            : Float = 0;
     @:noCompletion private var _widthUsePercent         : Bool = false;
@@ -57,11 +57,11 @@ class Widget extends TweenSprite{
     public var minHeightByContent = false;
 
     //Widget height height in pixels
-    public var h (get_h,set_h)  : Float;
+    public var h (get,set)  : Float;
     //Height of content area
-    public var contentHeight (get_contentHeight, null) : Float;
+    public var contentHeight (get, null) : Float;
     //Widget height in % of parent's height
-    public var heightPt (get_heightPt,set_heightPt) : Float;
+    public var heightPt (get,set) : Float;
     @:noCompletion private var _height                   : Float = 0;
     @:noCompletion private var _heightPercent            : Float = 0;
     @:noCompletion private var _heightUsePercent         : Bool = false;
@@ -72,19 +72,19 @@ class Widget extends TweenSprite{
     @:noCompletion private var _resizing : Bool = false;
 
     //Widget id (unique)
-    public var id (default, set_id) : String;
+    public var id (default, set) : String;
 
     //position this widget by left border in pixels
-    public var left (get_left,set_left) : Float;
+    public var left (get,set) : Float;
     //position this widget by left border in % of parent's width
-    public var leftPt (get_leftPt,set_leftPt) : Float;
+    public var leftPt (get,set) : Float;
     @:noCompletion private var _left                   : Float = 0;
     @:noCompletion private var _leftPercent            : Float = 0;
 
     //position this widget by right border in pixels
-    public var right (get_right,set_right) : Float;
+    public var right (get,set) : Float;
     //position this widget by right border in % of parent's width
-    public var rightPt (get_rightPt,set_rightPt)   : Float;
+    public var rightPt (get,set)   : Float;
     @:noCompletion private var _right                     : Float = 0;
     @:noCompletion private var _rightPercent              : Float = 0;
 
@@ -93,19 +93,19 @@ class Widget extends TweenSprite{
     @:noCompletion private var _yUse : Int = _Y_USE_TOP;
 
     //Get parent if it is widget, returns null otherwise
-    public var wparent (get_wparent,never) : Widget;
+    public var wparent (get,never) : Widget;
 
     //position this widget by top border in pixels
-    public var top (get_top,set_top)   : Float;
+    public var top (get,set)   : Float;
     //position this widget by top border in % of parent's height
-    public var topPt (get_topPt,set_topPt) : Float;
+    public var topPt (get,set) : Float;
     @:noCompletion private var _top                   : Float = 0;
     @:noCompletion private var _topPercent            : Float = 0;
 
     //position this widget by bottom border in pixels
-    public var bottom (get_bottom,set_bottom) : Float;
+    public var bottom (get,set) : Float;
     //position this widget by bottom border in % of parent's height
-    public var bottomPt (get_bottomPt,set_bottomPt)     : Float;
+    public var bottomPt (get,set)     : Float;
     @:noCompletion private var _bottom                       : Float = 0;
     @:noCompletion private var _bottomPercent                : Float = 0;
 
@@ -119,12 +119,12 @@ class Widget extends TweenSprite{
     */
     @:noCompletion public var _skinQueued : Bool = false;
     //skin name to use. One of registered with <type>ru.stablex.ui.UIBuilder</type>.regSkins()
-    public var skinName (default,set_skinName) : String;
+    public var skinName (default,set) : String;
     //whether widget content out of widgt bounds is visible
-    public var overflow (default,set_overflow) : Bool = true;
+    public var overflow (default,set) : Bool = true;
 
     //Tooltip for this widget. See <type>Tip</type> to know how to use it.
-    public var tip (default,set_tip) : Tip;
+    public var tip (default,set) : Tip;
 
     //layout manager
     public var layout : Layout;


### PR DESCRIPTION
Haxe 4 compatibility. Requires `haxe4` define so use lastest haxe 4 rc or set this define manually. Had checked all examples, everything which had been worked with 3.4.7  works with haxe 4 now.
The only exception is  `optionsList` which requires constructing instances according to xml children and set them to paths included dynamic fields. Post process branch of `UIBuilder.attr2Haxe()` need to be modified as well in the future.